### PR TITLE
Bump event API compatibility and prepare for v4.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ rvm:
   - jruby-1.7.23
 script: 
   - bundle exec rspec spec
+jdk: oraclejdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+ - internal: Upgrade event API dependency to support Logstash 2.4 & 5.x.
+ - internal: Bump dependency to ftw library to fix compatibility problem.
+
 ## 3.0.2
  - Depend on logstash-core-plugin-api instead of logstash-core,
    removing the need to mass update plugins on major releases of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-# 3.0.2
-  - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 3.0.1
-  - New dependency requirements for logstash-core for the 5.0 release
+## 3.0.2
+ - Depend on logstash-core-plugin-api instead of logstash-core,
+   removing the need to mass update plugins on major releases of
+   logstash
+
+## 3.0.1
+ - New dependency requirements for logstash-core for the 5.0 release
+
 ## 3.0.0
  - The "mode" option's "server" value has been removed since server mode
    isn't supported (and never has been). This could potentially affect
@@ -10,7 +14,9 @@
  - The "url" option is now mandatory.
 
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
-   instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
+ - Plugins were updated to follow the new shutdown semantic, this mainly
+   allows Logstash to instruct input plugins to terminate gracefully,
+   instead of using Thread.raise on the plugins' threads. Ref:
+   https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/logstash-input-websocket.gemspec
+++ b/logstash-input-websocket.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-websocket'
-  s.version         = '3.0.2'
+  s.version         = '4.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events over the websocket protocol."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'logstash-codec-json'
   s.add_runtime_dependency 'ftw', ['~> 0.0.46']


### PR DESCRIPTION
The code itself was already compatible with the new event API so it was just a matter of adjusting the gemspec.

Fixes #11