### PR TITLE
fix: Socket leak on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.5
+  - Fix socket leaks
+  - Add configuration for connection retrying with backoff.
+  - Add support for plugin shutdown.
+
 ## 4.0.4
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -48,7 +48,7 @@ input plugins.
 ===== `debug_status`
 
   * Value type is <<array,array>>
-  * Default value is `[404]`
+  * Default value is `[]`
 
 Logs responses with the given HTTP status codes as debug instead
 of warning.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -31,18 +31,27 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-debug_status>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-mode>> |<<string,string>>, one of `["client"]`|No
-| <<plugins-{type}s-{plugin}-url>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-retry_initial>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_max>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_reset>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-warn_404>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-url>> |<<string,string>>|Yes
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
 input plugins.
 
 &nbsp;
+
+[id="plugins-{type}s-{plugin}-debug_status"]
+===== `debug_status`
+
+  * Value type is <<array,array>>
+  * Default value is `[404]`
+
+Logs responses with the given HTTP status codes as debug instead
+of warning.
 
 [id="plugins-{type}s-{plugin}-mode"]
 ===== `mode`
@@ -54,6 +63,34 @@ Select the plugin's mode of operation. Right now only client mode
 is supported, i.e. this plugin connects to a websocket server and
 receives events from the server as websocket messages.
 
+[id="plugins-{type}s-{plugin}-retry_initial"]
+===== `retry_initial`
+
+  * Value type is <<number,number>>
+  * Default value is `1`
+
+The retry interval in seconds connections start with.
+
+[id="plugins-{type}s-{plugin}-retry_max"]
+===== `retry_max`
+
+  * Value type is <<number,number>>
+  * Default value is `60`
+
+The maximum retry interval in seconds backoff will increase to.
+
+[id="plugins-{type}s-{plugin}-retry_reset"]
+===== `retry_reset`
+
+  * Value type is <<number,number>>
+  * Default value is `1`
+
+The number of log entries that have to be processed before
+the retry interval is reset to retry_initial. This allows
+connections to quickly recover from a small interruption
+after we have successfully connected and processed some
+entries.
+
 [id="plugins-{type}s-{plugin}-url"]
 ===== `url`
 
@@ -62,42 +99,6 @@ receives events from the server as websocket messages.
   * There is no default value for this setting.
 
 The URL to connect to.
-
-[id="plugins-{type}s-{plugin}-retry_initial"]
-===== `retry_initial`
-
-  * Value type is <<number,number>>
-  * Default values is `1`
-
-The retry interval connections start with.
-
-[id="plugins-{type}s-{plugin}-retry_max"]
-===== `retry_max`
-
-  * Value type is <<number,number>>
-  * Default values is `60`
-
-The maximum retry interval backoff will increase too.
-
-[id="plugins-{type}s-{plugin}-retry_reset"]
-===== `retry_reset`
-
-  * Value type is <<number,number>>
-  * Default values is `20`
-
-The number of log entries that have to be processed before
-the retry interval is reset to retry_initial. This allows
-connections to quickly recover from a small interruption
-after we have successfully connected and processed some
-entries.
-
-[id="plugins-{type}s-{plugin}-warn_404"]
-===== `warn_404`
-
-  * Value type is <<boolean,boolean>>
-  * Default values is `true`
-
-Logs 404 responses as warnings if true otherwise as debug.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -33,6 +33,10 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-mode>> |<<string,string>>, one of `["client"]`|No
 | <<plugins-{type}s-{plugin}-url>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-retry_initial>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-retry_max>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-retry_reset>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-warn_404>> |<<boolean,boolean>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -41,7 +45,7 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-mode"]
-===== `mode` 
+===== `mode`
 
   * Value can be any of: `client`
   * Default value is `"client"`
@@ -51,7 +55,7 @@ is supported, i.e. this plugin connects to a websocket server and
 receives events from the server as websocket messages.
 
 [id="plugins-{type}s-{plugin}-url"]
-===== `url` 
+===== `url`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -59,7 +63,41 @@ receives events from the server as websocket messages.
 
 The URL to connect to.
 
+[id="plugins-{type}s-{plugin}-retry_initial"]
+===== `retry_initial`
 
+  * Value type is <<number,number>>
+  * Default values is `1`
+
+The retry interval connections start with.
+
+[id="plugins-{type}s-{plugin}-retry_max"]
+===== `retry_max`
+
+  * Value type is <<number,number>>
+  * Default values is `60`
+
+The maximum retry interval backoff will increase too.
+
+[id="plugins-{type}s-{plugin}-retry_reset"]
+===== `retry_reset`
+
+  * Value type is <<number,number>>
+  * Default values is `20`
+
+The number of log entries that have to be processed before
+the retry interval is reset to retry_initial. This allows
+connections to quickly recover from a small interruption
+after we have successfully connected and processed some
+entries.
+
+[id="plugins-{type}s-{plugin}-warn_404"]
+===== `warn_404`
+
+  * Value type is <<boolean,boolean>>
+  * Default values is `true`
+
+Logs 404 responses as warnings if true otherwise as debug.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/inputs/websocket.rb
+++ b/lib/logstash/inputs/websocket.rb
@@ -1,8 +1,7 @@
 # encoding: utf-8
 require "logstash/inputs/base"
 require "logstash/namespace"
-require "socket"
-
+require "stud/interval"
 
 # Read events over the websocket protocol.
 class LogStash::Inputs::Websocket < LogStash::Inputs::Base
@@ -13,8 +12,18 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
   # The URL to connect to.
   config :url, :validate => :string, :required => true
 
-  # Retry interval.
-  config :retry, :validate => :number, :default => 1
+  # The retry interval connections start with.
+  config :retry_initial, :validate => :number, :default => 1
+
+  # The maximum retry interval backoff will increase too.
+  config :retry_max, :validate => :number, :default => 60
+
+  # The number of log entries that have to be processed before
+  # the retry interval is reset to retry_initial.
+  config :retry_reset, :validate => :number, :default => 20
+
+  # Logs 404 responses as warnings if true otherwise as debug.
+  config :warn_404, :validated => :boolean, :default => true
 
   # Select the plugin's mode of operation. Right now only client mode
   # is supported, i.e. this plugin connects to a websocket server and
@@ -23,35 +32,90 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
 
   def register
     require "ftw"
+    require "uri"
+
+    p = URI.parse(@url)
+    if p.userinfo != ""
+      p.userinfo = "***:***"
+    end
+
+    @url_safe = p.to_s
+    @interval = @retry_initial
+    @agent = FTW::Agent.new
+    @processed = 0
   end # def register
 
   public
   def run(output_queue)
-    agent = FTW::Agent.new
-    begin
-      websocket = agent.websocket!(@url)
-      websocket.each do |payload|
+    @logger.info("Starting", :url => @url_safe)
+    while !stop?
+      run_single(output_queue)
+      Stud.stoppable_sleep(@interval) { stop? }
+      backoff()
+    end # loop
+  end # def run
+
+  def stop
+    # Force close all connections to escape any blocking reads.
+    cleanup()
+  end # def stop
+
+  private
+  def cleanup()
+    @agent.shutdown() rescue nil
+  end # def cleanup
+
+  def run_single(output_queue)
+    @processed = 0
+    r = @agent.websocket!(@url)
+    if r.instance_of?(FTW::WebSocket)
+      r.each do |payload|
         @codec.decode(payload) do |event|
           decorate(event)
           output_queue << event
+          @processed += 1
         end
       end
-    rescue => e
-      @logger.warn("websocket input client threw exception, restarting",
-                   :exception => e)
-      # Ensure all connections are cleaned up before retrying.
-      begin
-        agent.shutdown()
-      rescue => e
-        @logger.warn("websocket input client exception on shutdown",
-                     :exception => e)
+    elsif r.instance_of?(FTW::Response)
+      if r.status != 404 || @warn_404
+        @logger.warn("Connect failed",
+                     :status => r.status_line,
+                     :url => @url_safe,
+                     :retry => @interval) unless stop?
+      else
+        @logger.debug("Connect failed",
+                     :status => r.status_line,
+                     :url => @url_safe,
+                     :retry => @interval) unless stop?
       end
-      sleep(@retry)
-      retry
-    ensure
-      # Ensure all connections are cleaned up.
-      agent.shutdown()
-    end # begin
-  end # def run
+    else
+      @logger.warn("Connect unexpected type",
+                   :type => r.class.name,
+                   :url => @url_safe,
+                   :retry => @interval) unless stop?
+    end
+  rescue EOFError => e
+    @logger.debug("Run error ",
+                 :exception => e,
+                 :url => @url_safe,
+                 :retry => @interval) unless stop?
+  rescue => e
+    @logger.warn("Run error ",
+                 :exception => e,
+                 :url => @url_safe,
+                 :retry => @interval) unless stop?
+  ensure
+    cleanup()
+  end # def run_single
+
+  def backoff()
+    if @processed > @retry_reset
+      @interval = @retry_initial
+    elsif @interval * 2 >= @retry_max
+      @interval = @retry_max
+    else
+      @interval = @interval * 2
+    end
+  end # def backoff
 
 end # class LogStash::Inputs::Websocket

--- a/lib/logstash/inputs/websocket.rb
+++ b/lib/logstash/inputs/websocket.rb
@@ -27,7 +27,7 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
 
   # Logs responses with the given HTTP status codes as debug instead
   # of warning.
-  config :debug_status, :default => [404]
+  config :debug_status, :valdate => :array, :default => []
 
   # Select the plugin's mode of operation. Right now only client mode
   # is supported, i.e. this plugin connects to a websocket server and
@@ -39,9 +39,7 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
     require "uri"
 
     p = URI.parse(@url)
-    if p.userinfo != ""
-      p.userinfo = "***:***"
-    end
+    p.userinfo = "***:***" unless p.userinfo.nil?
 
     @url_safe = p.to_s
     @interval = @retry_initial

--- a/lib/logstash/inputs/websocket.rb
+++ b/lib/logstash/inputs/websocket.rb
@@ -27,7 +27,7 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
 
   # Logs responses with the given HTTP status codes as debug instead
   # of warning.
-  config :debug_status, :valdate => :array, :default => []
+  config :debug_status, :validate => :array, :default => []
 
   # Select the plugin's mode of operation. Right now only client mode
   # is supported, i.e. this plugin connects to a websocket server and

--- a/lib/logstash/inputs/websocket.rb
+++ b/lib/logstash/inputs/websocket.rb
@@ -19,7 +19,10 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
   config :retry_max, :validate => :number, :default => 60
 
   # The number of log entries that have to be processed before
-  # the retry interval is reset to retry_initial.
+  # the retry interval is reset to retry_initial. This allows
+  # connections to quickly recover from a small interruption
+  # after we have successfully connected and processed some
+  # entries.
   config :retry_reset, :validate => :number, :default => 20
 
   # Logs 404 responses as warnings if true otherwise as debug.
@@ -111,10 +114,8 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
   def backoff()
     if @processed > @retry_reset
       @interval = @retry_initial
-    elsif @interval * 2 >= @retry_max
-      @interval = @retry_max
     else
-      @interval = @interval * 2
+      @interval = [@interval * 2, @retry_max].min
     end
   end # def backoff
 

--- a/logstash-input-websocket.gemspec
+++ b/logstash-input-websocket.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-websocket'
-  s.version         = '4.0.4'
+  s.version         = '4.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a websocket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fix sockets being leaked if we get any errors by calling agent.shutdown to close all active connections.

Improve connection handling adding support for backoff and connection termination on logstash shutdown.

New configuration options added:
* retry_initial
* retry_max
* retry_reset
* debug_status

Also:
* Remove unused socket require.
* Clean up logging.
* Bump version to 4.0.5

Fixes #20 
Fixes #21